### PR TITLE
fix(openclaw): resolve duplicate ocResults id + eeon page fixes

### DIFF
--- a/TMAR-Accrual-Ledger.html
+++ b/TMAR-Accrual-Ledger.html
@@ -34337,7 +34337,7 @@ trusteeName + ', known to me (or satisfactorily proven) to be the\n' +
             <button class="btn btn-sm" onclick="openClawCongress()" style="font-size:10px;background:rgba(255,215,0,.15);color:#ffd700">📋 Congressional Record</button>
           </div>
           <input id="ocQuery" placeholder="Search term (case name, statute, topic)..." style="width:100%;margin-top:8px;padding:6px;background:var(--input-bg);border:1px solid rgba(255,215,0,.3);border-radius:6px;color:var(--text);font-size:11px">
-          <div id="ocResults" style="margin-top:8px;font-size:11px;max-height:200px;overflow-y:auto;color:var(--text2);line-height:1.7"></div>
+          <div id="ocResultsApitools" style="margin-top:8px;font-size:11px;max-height:200px;overflow-y:auto;color:var(--text2);line-height:1.7"></div>
         </div>
         <div id="apicard-apify" style="padding:14px;border-radius:10px;border:1px solid rgba(6,182,212,.3);background:rgba(6,182,212,.05)">
           <div style="font-weight:700;font-size:13px;color:#06b6d4;margin-bottom:4px">🕷️ Apify Research Engine</div>


### PR DESCRIPTION
## Summary
- Fixes Legal/Finance/Government/Business/Documents category tabs on OpenClaw page (duplicate `id="ocResults"` was silently redirecting output to hidden apitools card)
- Repairs eeonfull iframe URL to load gas/E-Longmire Estate file
- Fixes eeon_suite Return to Ledger button, Accrual Ledger tile, Tax Forms tile
- Inserts missing `</div>` that was trapping 15 EON sub-pages inside page-aihub
- Merges real EEON Form 1120 rendering engine (replaces all stubs)

## Test plan
- [ ] OpenClaw → click Legal/Finance/Government/Business/Documents — results appear in the correct box
- [ ] EEON Full Suite page renders E-Longmire iframe
- [ ] EEON Suite page: Return to Ledger / module tiles work
- [ ] All 51 EON pages navigate without JS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)