### PR TITLE
fix(gas): correct TMARBridge read-side to real 29-col schema; sync docs

### DIFF
--- a/.claude/docs/gas-patterns.md
+++ b/.claude/docs/gas-patterns.md
@@ -26,7 +26,7 @@ const ss = SpreadsheetApp.getActiveSpreadsheet();
 const sheet = ss.getSheetByName('Master Register');
 const lastRow = sheet.getLastRow();
 if (lastRow < 2) return []; // empty sheet guard
-const data = sheet.getRange(2, 1, lastRow - 1, 35).getValues(); // skip header, all 35 cols
+const data = sheet.getRange(2, 1, lastRow - 1, 29).getValues(); // skip header, all 29 cols (A-AC)
 ```
 
 Row index is 1-based in GAS. Column A = index 1.
@@ -35,10 +35,12 @@ Row index is 1-based in GAS. Column A = index 1.
 
 ```javascript
 sheet.insertRows(2, 1);                           // insert before existing data
-sheet.getRange(2, 1, 1, 35).setValues([rowArray]); // write single row (array of 35 values)
+sheet.getRange(2, 1, 1, 29).setValues([rowArray]); // write single row (array of 29 values)
 ```
 
-Always provide all 35 values for the Master Register — use `""` for empty cells.
+Always provide all 29 values for the Master Register — use `""` for empty cells. See
+`.claude/docs/domain-models.md` for the verified 29-column (A–AC) schema — re-verify against
+`?action=pullRawTab` before trusting any doc's column count, including this one.
 
 ## Dialog/Sidebar Launchers
 
@@ -125,4 +127,6 @@ The exec URL does not change on redeploy.
 
 ## Sheet Name Constants (never misspell)
 
-Master Register, Transaction Ledger, _Validation, Executive Dashboard, W-2 & Income Detail, BOA Cash Flow, PNC Cash Flow, Household Obligations, Subscriptions & Services, Tax Strategy, Trust Ledger, 1099 Filing Chain, Forms & Authority, Proof of Mailing, Document Inventory, Document Registry, _HealthAudit
+Master Register, Transaction Ledger, _Validation, Executive Dashboard, W-2 & Income Detail, BOA Cash Flow, PNC Cash Flow, Household Obligations, Subscriptions & Services, Tax Strategy, 1099 Filing Chain, Forms & Authority, Proof of Mailing, Document Inventory, Document Registry, _HealthAudit
+
+`Trust Ledger` is retired (2026-07-31, hidden not deleted, `gas/RetireTrustLedger.gs`) — do not read/write it; trust corpus assets live in `📦 Asset Transfer Log`'s Schedule A section instead.

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ The YouTube playlist Download + Transcribe pipeline (and its local companion ser
 
 | Group | Tabs (examples) |
 |---|---|
-| **Account spine** | `Master Register` (35-col canonical, `MR-NNN`), `Master Register Archive` (dedup quarantine), `Account Entities`, `CoA`, `Principal Register` |
-| **Ledgers** | `Transaction Ledger`, `Trust Ledger`, `Acct Ledger`, cash flows (`BOA`, `PNC`) |
+| **Account spine** | `Master Register` (29-col canonical, A–AC, `MR-NNN`), `Master Register Archive` (dedup quarantine), `Account Entities`, `CoA`, `Principal Register` |
+| **Ledgers** | `Transaction Ledger`, `Acct Ledger`, cash flows (`BOA`, `PNC`) — `Trust Ledger` retired 2026-07-31 (hidden; trust corpus assets now live in `📦 Asset Transfer Log`'s Schedule A section) |
 | **Creditors / 1099** | `Creditor Registry` + `Checklist` (enriched 20-subsets) · `FWM — Creditor Detail` + `FWM — Forms Checklist` (28-creditor master) · `1099 Filing Chain`, `1099 Filings`, `Forms & Authority`, `Proof of Mailing` |
 | **Documents** | `Document Registry` (PC FileCabinet scan, canonical `DOC-NNNN`), `Document Inventory` (separate catalog) |
 | **Tax** | `W-2 & Income Detail`, `Schedule A`, `1040 Submissions`, `Tax Strategy` |
@@ -154,7 +154,7 @@ The YouTube playlist Download + Transcribe pipeline (and its local companion ser
 | `RemoveArchiveBanner.gs` | One-shot guarded cleanup utility |
 | `PopulateValidation.gs` · `FormattingComplement.gs` · `TMAR_AestheticsAndAudit.gs` | Validation lists, conditional formatting, health audit |
 
-**Web App actions:** `getMasterRegister`, `getTransactionLedger`, `pushEntities`, `pushTransactions`, `pushPayables`, `push1099s`, `listWorkbookTabs`, `pullWorkbookSheets`, `listSheetTabs`, `pullRawTab`, importers (`importSubstituteW2`, `importForm1040`, `importForm2848`, `importScheduleA`).
+**Web App actions:** `pullAccounts`, `pullTransactions`, `pushEntities`, `pushTransactions`, `pushPayables`, `push1099`, `listWorkbookTabs`, `pullWorkbookSheets`, `listSheetTabs`, `pullRawTab`, `runFunction`/`listRunnableFunctions` (safe-invoke, 23-function allowlist), `deleteWebsiteAccounts` (backed-up delete), importers (`importSubstituteW2`, `importForm1040`, `importForm2848`, `importScheduleA`).
 
 All workbook IDs are centralized in **`TMAR_CONFIG`** (top of `SyncCenter.gs`): `liveBookId`, `sourceBookId` (= live), `appcHubId` (folded into live 2026-06-27), `archiveBookId`. Never hardcode an ID elsewhere. See `gas/README.md`.
 
@@ -298,7 +298,7 @@ TMAR-Accrual-Ledger/
 | Doc | Covers |
 |---|---|
 | `.claude/docs/data-topology.md` | Full data-relationship map (source of truth for injected `ledgerTopology`) |
-| `.claude/docs/domain-models.md` | Schemas — Master Register 35-col, Account/Transaction models |
+| `.claude/docs/domain-models.md` | Schemas — Master Register 29-col (A–AC), Account/Transaction models |
 | `.claude/docs/ledger-calculation-rules.md` | Balance / income / verification rules |
 | `.claude/docs/api-patterns.md` | LLM call stack, CORS, provider routing, TTS |
 | `.claude/docs/transcript-transformer.md` | Merged-mode prompt rules, Upgrade tool, Process Tracker JSON schema, File System Access API constraints |

--- a/VaultIndex.md
+++ b/VaultIndex.md
@@ -103,7 +103,6 @@ flowchart TD
 | Tab | Key Columns | Join Key |
 |-----|------------|----------|
 | Transaction Ledger | 16 cols | Date/Vendor |
-| Trust Ledger | 8 cols | Asset |
 | Acct Ledger | 16 cols | EIN |
 | BOA Cash Flow | 8 cols | Month |
 | PNC Cash Flow | 8 cols | Month |
@@ -141,6 +140,7 @@ flowchart TD
 | _Validation | Dropdown lists |
 | _SyncMeta | Sync state tracking |
 | _YearData | Year-specific config |
+| Trust Ledger | **Retired 2026-07-31** (hidden, not deleted — `gas/RetireTrustLedger.gs`). Trust corpus assets now live in `📦 Asset Transfer Log`'s embedded Schedule A section. Do not resurrect. |
 
 ### Trust Binder
 Emoji-prefixed: 📋 HUB INDEX · 📒 General Ledger · 📊 Corpus & M-2 · …
@@ -171,6 +171,7 @@ Emoji-prefixed: 📋 HUB INDEX · 📒 General Ledger · 📊 Corpus & M-2 · �
 | `pullContacts` | GET | Key required | Contacts |
 | `pullWebsiteAccounts` | GET | Key required | Website logins (no passwords) |
 | `listSheetTabs` | GET | Key required | Tab names |
+| `listRunnableFunctions` | GET | Key required | Names of the 23 hard-allowlisted GAS functions `runFunction` (doPost) may invoke |
 | `listWorkbookTabs` | GET | Key required | All workbook tabs |
 | `pullWorkbookSheets` | GET | Key required | Selected tabs as JSON |
 | `pullRawTab` | GET | Key required | Raw tab data |
@@ -199,6 +200,8 @@ Emoji-prefixed: 📋 HUB INDEX · 📒 General Ledger · 📊 Corpus & M-2 · �
 | `TMAR_AestheticsAndAudit.gs` | Health audit + aesthetics |
 | `TransactionLedgerTrackingFix.gs` | Ledger tracking fixes |
 | `ReconcileCrossFill.gs` | Capture-once propagation (in progress) |
+| `RunnableFunctionsAllowlist.gs` | 23-function hard-allowlist backing the `runFunction`/`listRunnableFunctions` safe-invoke endpoints |
+| `embedUrlsAsHyperlinks.gs` | Converts platform-name cells → `=HYPERLINK()` formulas from the URL column |
 | `RemoveArchiveBanner.gs` | One-shot cleanup |
 | `ExecuteCleanup.gs` | Cleanup execution |
 | `addFillingPackage2025.gs` | 2025 filing package |

--- a/docs/CODE_AUDIT_2026-08-06.md
+++ b/docs/CODE_AUDIT_2026-08-06.md
@@ -1,0 +1,341 @@
+# Code Audit Report — TMAR Accrual Ledger
+**Date:** 2026-08-06 | **Auditor:** Hermes Agent (law profile) | **Thoroughness:** Standard
+
+---
+
+## Executive Summary
+
+- **Overall health score:** **58/100** (needs attention)
+- **Critical issues:** 3
+- **High-priority issues:** 7
+- **Medium-priority issues:** 11
+- **Top 3 priorities:**
+  1. **Schema drift breaking data integrity** — SheetsService.js (JavaScript) uses 35-column schema that was corrected to 29 columns in TMARBridge.gs on 2026-08-03 but never synced back to JS sources. Every `readMasterRegister()`, `writeMasterRegisterAccount()`, `accountToRow()`, and `rowToAccount()` in the JS layer operates on wrong column offsets.
+  2. **Test suite is broken** — jest-29.7.0 fails to install (dependency conflict with jspdf→dompurify), 0% coverage verifiable. Four test files exist but cannot be executed.
+  3. **Critical NPM vulnerability** — dompurify ≤3.4.11 (transitive via jspdf 2.5.1) has 17 published XSS CVEs. jspdf 4.2.1 would fix but requires migration.
+
+---
+
+## Metrics
+
+| Metric | Count |
+|---|---|
+| Files analyzed | 259+ (excluding gitignored/node_modules) |
+| Lines of code | ~205,000 across .js/.html/.gs/.mjs |
+| JavaScript (src/) | 22 files, 9,387 lines |
+| Google Apps Script (gas/) | 36 files, 22,598 lines |
+| HTML (app+tools) | 27 files, 120,751 lines |
+| Main single-file app | 3,813 KB, 55,163 lines |
+| Documentation (.md) | 130 files, 34,429 lines |
+| Production dependencies | 2 (html2canvas, jspdf) |
+| Dev dependencies | 5 (jest, jsdom, testing-library, playwright) |
+| Test files | 4 files, ~716 lines of tests |
+| Test coverage (verified) | 0% (suite broken) |
+| Complexity hotspot | TMAR-Accrual-Ledger.html (55K lines in single file) |
+
+---
+
+## Findings by Category
+
+### 1. Architecture & Design
+
+#### 🔴 Critical — Schema drift between JS and GAS layers
+
+- **SheetsService.js:8** — `MASTER_REGISTER_SCHEMA` defines **35 columns** (indices 0–34):
+  ```js
+  export const MASTER_REGISTER_SCHEMA = {
+    ROW_ID: 0, DATE_ADDED: 1, PROVIDER: 2, MAILING_ADDRESS: 3,
+    PROVIDER_EIN: 4, ACCOUNT_NUMBER: 5, ...
+    DISCOVERY_STATUS: 34   // AI: Discovery Status
+  };
+  ```
+- **TMARBridge.gs:142** (corrected 2026-08-03) — `addTMARAccount()` writes a **29-column** row (A–AC), with completely different field positions. `readMasterRegisterAccounts_()` at TMARBridge.gs:211 still reads *35* columns via `getRange(2,1,lastRow-1,35)` but maps them to the old 35-column indices.
+- **Impact:** Every JS-to-GAS round-trip through SheetsService silently corrupts column positions. `addAccount()` → `writeMasterRegisterAccount()` writes 35 values to a 29-column schema. `readMasterRegister()` maps the wrong columns into account objects.
+- **Recommendation:** Freeze the canonical schema in ONE place (either GAS or JS), update the other side to match, and add a runtime schema-version check on every read.
+
+#### 🔴 Critical — 55K-line monolithic single-file HTML application
+
+- **TMAR-Accrual-Ledger.html:55,163 lines, 3,813 KB** — 246 functions, 19 agents, LLM streaming, DOM rendering, CORS proxy routing, and full application logic in one file.
+- **Impact:** Impossible to review, diff, or maintain. No modularization boundaries. Any change risks cascading breakage. Git diffs for this file are unreadable.
+- **Recommendation:** Break into ES modules served via `<script type="module">` or a build step (Vite/Rollup). Minimum: extract agents, DOM rendering, API layer, and utility functions into separate files.
+
+#### 🟡 Medium — Dual source-of-truth pattern without sync enforcement
+
+- The CLAUDE.md explicitly states that two pairs live in "two synced places": fiduciary doc factory (`.claude/skills/` ↔ `DOCUMENT_KNOWLEDGE.fiduciaryDocFactory` inline in HTML) and ledger topology (`.claude/docs/data-topology.md` ↔ `DOCUMENT_KNOWLEDGE.ledgerTopology` inline in HTML). There is no automated verification that these pairs are in sync.
+- **Impact:** Divergence risk between docs and injected prompts. Agents using stale knowledge.
+- **Recommendation:** Add a CI/lint step that diffs the source-of-truth against the HTML-embedded copies and fails on mismatch.
+
+#### 🟡 Medium — Mixed concern: Obsidian vault + Git repo + GAS project
+
+- The same directory is an Obsidian vault (.obsidian/ config), a Git-tracked JavaScript project, and the deployment source for a Google Apps Script project (gas/ with .clasp.json).
+- **Impact:** Tooling conflicts (Obsidian plugins auto-modify files, git sees changes; .gitignore must be maintained across all three surfaces). New contributors face steep onboarding.
+- **Recommendation:** Document the triple-role architecture explicitly. Consider a pre-commit hook that warns if Obsidian config files are staged.
+
+#### 🟢 Low — Unused service files
+
+- **InvoiceService.js (204 lines)** and **PayrollService.js (247 lines)** are fully implemented but are not referenced by any consumer in the codebase. `src/index.js` imports them but they are never called by the main HTML app or GAS bridge.
+- **Impact:** Dead code that adds maintenance burden and test surface without value.
+- **Recommendation:** Either wire them into the app or archive them.
+
+---
+
+### 2. Code Quality
+
+#### 🔴 High — 35-column schema still referenced in active JS code
+
+- **SheetsService.js:8,98,155,219** — Every method uses 35 as the column count. The real schema was corrected to 29 columns. This is the same issue as Architecture finding #1, classified here as a code quality defect because the fix is a simple constant update — but it hasn't been done.
+- **Recommendation:** Update `MASTER_REGISTER_SCHEMA` and all dependent row indices to match the 29-column schema documented in `domain-models.md` and implemented in TMARBridge.gs:addTMARAccount().
+
+#### 🟡 Medium — 70 `console.log/warn/error` calls remain in production JavaScript
+
+- **tt_block.js:49 occurrences** — a 49-location log surface, likely from the Transcript Transformer block embedded in the main app.
+- **src/index.js:2**, **SheetsService.js:1**, **StateManager.js:1**, **LocalStorage.js:7** — straightforward log patterns.
+- **Impact:** Console logs in production leak internal state and slow execution in the browser. The Transcript Transformer block (tt_block.js) being the worst offender.
+- **Recommendation:** Wrap console calls behind a debug flag, strip in production build, or use a logging framework with levels.
+
+#### 🟡 Medium — 7 TODO/FIXME/HACK markers in active code
+
+- **TMARService.js:1** — TODO in comment (unclear what)
+- **SheetsService.js:2** — TODO items
+- **tt_block.js:1** — one FIXME
+- **backup_20260228/CreditReportImport.js:2** — archived but indicates recent tech debt
+- **Recommendation:** Either resolve or promote to tracked issues. Archived backup files should be cleaned.
+
+#### 🟡 Medium — 1,049 `.innerHTML =` assignments across HTML files
+
+- **TMAR-Accrual-Ledger.html:445** — the main app alone has 445 direct innerHTML assignments. The GAS HTML dialogs (GAAPInterface:10, ControlPanel:7, EINVerifier:6, etc.) contribute to the rest.
+- **Impact:** While most are against trusted strings, this pattern is a recognized XSS vector if any user-controlled data flows through. The sheer volume makes auditing impossible.
+- **Recommendation:** Audit the 445 assignments in the main app for any that receive user input or API responses. Replace with `textContent` where only text is needed, and use DOMPurify (already in the dependency tree as a jspdf transitive) for HTML content.
+
+#### 🟢 Low — `substr()` deprecation
+
+- **AccountService.js:72, TransactionService.js:71, InvoiceService.js:86, PayrollService.js:66** — `String.prototype.substr()` is used for generating random ID suffixes. This method is deprecated (MDN marks it as "avoid").
+- **Recommendation:** Replace with `String.prototype.substring()` or `String.prototype.slice()`.
+
+#### 🟢 Low — Inconsistent ID generation strategies
+
+- Accounts use `ACC-` prefix (AccountService.js), Master Register uses `MR-` prefix (SheetsService.js), Transactions use `TXN-` (TransactionService.js), Invoices use `INV-` (InvoiceService.js), Employees use `EMP-` (PayrollService.js). Five different ID strategies with no shared factory.
+- **Recommendation:** Centralize ID generation into a shared utility.
+
+---
+
+### 3. Security
+
+#### 🔴 Critical — NPM dependencies have known XSS vulnerabilities
+
+- **dompurify ≤3.4.11** (transitive via `jspdf ^2.5.1`) — 17 published CVEs for XSS bypasses.
+- **jspdf ≤4.2.0** — directly affected.
+- **Impact:** If any user-supplied content is rendered through jspdf (PDF export), XSS is possible.
+- **Recommendation:** `npm audit fix --force` to upgrade jspdf to 4.2.1 (breaking change — verify PDF export still works). If jspdf 4.x migration is too large, pin dompurify separately at latest and test.
+
+#### 🟡 Medium — API key in localStorage, not HTTP-only
+
+- The CORS proxy key and API keys are stored in browser `localStorage`. Any XSS on the page can exfiltrate them.
+- **Impact:** localStorage is accessible to all JavaScript running on the origin, including any injected scripts.
+- **Recommendation:** For the CORS proxy key, consider session-only storage. At minimum, document that keys stored in localStorage are susceptible to XSS exfiltration.
+
+#### 🟡 Medium — No input sanitization on JSON import
+
+- **TMARService.js:370-398** — `importFromJSON()` parses arbitrary JSON and directly sets it as application state without validation of individual fields beyond checking that `accounts` is an array.
+- **Impact:** Malformed JSON (injected balances, XSS payloads in names/notes) can corrupt the Master Register.
+- **Recommendation:** Validate each account object through `AccountService.validateAccount()` before ingestion, and sanitize string fields.
+
+#### 🟢 Low — GAS innerHTML usage is controlled but not audited
+
+- **gas/Code.gs:3124-3131** — Three innerHTML assignments for status messages, using only hardcoded strings and `.error.message`. Low risk but non-zero.
+- **Recommendation:** Replace with `textContent` where possible.
+
+#### 🟢 Low — GAS SyncCenter.gs API key gate is well-implemented
+
+- **SyncCenter.gs** — `checkApiKey_()` is properly applied to all doGet/doPost actions except `ping`. Credentials are stripped at the GAS layer. This is a positive finding — the authentication model is sound.
+
+---
+
+### 4. Performance
+
+#### 🟡 Medium — No build step for the 3.8 MB main application
+
+- The entire app is served as a single 3,813 KB HTML file with no minification, tree-shaking, or code splitting.
+- **Impact:** First-load time is dominated by parse/compile of 55K lines of JavaScript. On slow connections, this is seconds of blank screen.
+- **Recommendation:** Add a Vite or Rollup build step that splits the application into chunks with dynamic imports. At minimum, minify the JavaScript.
+
+#### 🟡 Medium — DOM reflows from 445 innerHTML assignments
+
+- Each `innerHTML =` forces the browser to parse HTML, reconstruct the DOM subtree, and recalculate layout. The main app has 445 of these.
+- **Impact:** Cumulative layout thrashing during account list rendering, dashboard updates, and agent responses.
+- **Recommendation:** Batch DOM updates using `DocumentFragment` or a virtual DOM approach. The LLM streaming UI is the most visible hotspot.
+
+#### 🟢 Low — No lazy loading for tools/
+
+- Seven standalone HTML tools (~2 MB combined) in `tools/` are loaded eagerly via iframes or direct navigation, not on-demand.
+- **Impact:** None — these are separate pages navigated to independently, not loaded with the main app.
+- **Recommendation:** N/A — current approach is fine for tools that are separate pages.
+
+#### 🟢 Low — GAS reads entire sheet on every operation
+
+- **readMasterRegisterAccounts_()** at TMARBridge.gs:211 reads `getRange(2,1,lastRow-1,35)` — the entire Master Register — on every dashboard load. For ~150 rows this is fast, but will degrade linearly.
+- **Impact:** Minimal today (<1s for 150 rows). Becomes relevant at 1,000+ rows.
+- **Recommendation:** Consider caching with `CacheService` for reads, invalidated on writes.
+
+---
+
+### 5. Testing
+
+#### 🔴 Critical — Test suite is non-functional
+
+- **Jest 29.7.0 fails to install** due to a dependency conflict between jspdf → dompurify. The `npm install` output shows only 21 packages installed (html2canvas + jspdf + their deps), but jest and its 200+ transitive dependencies are missing.
+- **Four test files exist** (716 lines of tests across AccountService, StateManager, TMARService, TMARInspectorService) with good coverage patterns — but **zero can be executed**.
+- **Impact:** No regression safety net. Any change to src/ services has no automated verification.
+- **Recommendation:** Resolve the jspdf→dompurify conflict first, then verify tests pass. This is the single highest-impact fix for long-term maintainability.
+
+#### 🟡 Medium — Coverage threshold defined but unenforceable
+
+- **package.json:46-52** — Jest is configured with 70% coverage thresholds across branches, functions, lines, and statements. The `src/` directory is properly scoped. But since tests can't run, the thresholds are aspirational.
+- **Recommendation:** Once tests are executable, run `npm run test:coverage` and adjust thresholds to match reality before ratcheting up.
+
+#### 🟡 Medium — Missing test files for three services
+
+- **TransactionService.js (232 lines)** — no `TransactionService.test.js` exists, despite 8 exported functions with complex logic (net income calculation, date filtering, category grouping, monthly spending).
+- **InvoiceService.js (204 lines)** — no test file. 10 exported functions including tax calculation and revenue aggregation.
+- **PayrollService.js (247 lines)** — no test file. 8 exported functions including progressive tax bracket calculation and SS wage base logic — these have real dollar impacts if wrong.
+- **Impact:** The three most business-critical services (money math) are completely untested.
+- **Recommendation:** Write tests for all three, prioritizing PayrollService (progressive tax brackets are error-prone) and TransactionService.
+
+#### 🟢 Low — Existing test quality is good
+
+- **AccountService.test.js (251 lines)** — 16 tests covering validation, creation, aggregation, filtering, searching, and immutable updates. Tests both happy paths and error cases.
+- **StateManager.test.js (126 lines)** — 10 tests covering initialization, immutability, observer notification, unsubscribe, error isolation, and factory function.
+- **TMARService.test.js (254 lines)** — 14 tests covering initialization, CRUD, financial summary, search, and JSON import/export. Properly mocks localStorage.
+- **TMARInspectorService.test.js (85 lines)** — 4 tests covering function registration, instrumentation, and report generation.
+- **Positive finding:** The test patterns are solid — pure functions, no DOM, clear arrange-act-assert. The tests that exist are well-written.
+
+---
+
+### 6. Maintainability
+
+#### 🟡 Medium — 130 markdown documentation files with drift risk
+
+- The `docs/` directory has 34 markdown files (14,505 lines). Many are handoff notes, implementation plans, and revision-specific documents that may be stale. The `GSheet/` directory duplicates some content from docs/ and `_archive/`.
+- **Impact:** A new developer doesn't know which docs are current vs. historical. Time is wasted cross-referencing.
+- **Recommendation:** Add "Last Verified: YYYY-MM-DD" frontmatter to all docs. Archive docs older than 6 months that describe completed work. Tag docs as `current`, `historical`, or `draft`.
+
+#### 🟡 Medium — 36 GAS files with no module system
+
+- Google Apps Script has no native `import`/`export`. 36 `.gs` files share a global namespace via file load order. Function name collisions would silently clobber.
+- **Impact:** Adding a new `.gs` file requires auditing all existing files for name conflicts. The `RunnableFunctionsAllowlist.gs` and `PopulateAppScriptsInventory.gs` files attempt to catalog this but are themselves part of the problem.
+- **Recommendation:** Document the load order and naming convention explicitly. Consider migrating to clasp with ES modules (if supported by newer Apps Script runtime) or using a namespace prefix convention.
+
+#### 🟡 Medium — No CI/CD
+
+- CLAUDE.md states "No CI/CD — run `npm test` locally before pushing HTML changes." Since `npm test` is broken, even the manual gate doesn't work.
+- **Impact:** No automated quality enforcement. The schema drift between JS and GAS layers would have been caught by a simple CI test that validated column counts.
+- **Recommendation:** Add GitHub Actions for: (a) `npm test` on push, (b) schema validation script, (c) linting. This is a one-time setup with lasting ROI.
+
+#### 🟡 Medium — CLAUDE.md is 350+ lines
+
+- The project context file is comprehensive but verbose. Some entries are historical (e.g., "backup_20260228" references, old schema notes) and may mislead if read without cross-referencing.
+- **Impact:** Agents (both human and AI) spend time parsing stale information.
+- **Recommendation:** Trim to current-state facts. Move historical entries to a `HISTORY.md` changelog.
+
+#### 🟢 Low — `gas/TMAR_AestheticsAndAudit.gs` is superseded but not archived
+
+- CLAUDE.md documents this as superseded by FormattingComplement.gs. It still exists in the active `gas/` directory and is loaded by clasp.
+- **Impact:** Functions loaded but never called. Poses a name-collision risk.
+- **Recommendation:** Move to `gas/_superseded/` or delete.
+
+#### 🟢 Low — Good conventions exist
+
+- **Positive finding:** The project has well-documented conventions: immutability for service functions, colon-hyphenated name format, 10pt TNR for fiduciary docs, DOC-ID registry system, GPO 2016 editorial rules. These are explicitly stated and consistently followed.
+
+---
+
+## Prioritized Action Plan
+
+### Quick Wins (< 1 day)
+
+| # | Action | Effort | Impact |
+|---|---|---|---|
+| 1 | **Fix the schema drift** — Update `SheetsService.js` MASTER_REGISTER_SCHEMA to 29 columns matching TMARBridge.gs | 2h | Data integrity |
+| 2 | **Fix test suite** — Resolve jspdf→dompurify conflict, verify all 4 test files pass | 2h | Safety net restored |
+| 3 | **Fix NPM vulnerabilities** — `npm audit fix --force` and verify PDF export | 1h | Security |
+| 4 | **Remove dead code** — Archive unused InvoiceService/PayrollService or wire them in | 1h | Clarity |
+| 5 | **Archive TMAR_AestheticsAndAudit.gs** — Move to `gas/_superseded/` | 15m | Clarity |
+
+### Medium-term Improvements (1–5 days)
+
+| # | Action | Effort | Impact |
+|---|---|---|---|
+| 6 | **Write tests for TransactionService, InvoiceService, PayrollService** | 8h | 100% service coverage |
+| 7 | **Add CI/CD pipeline** — GitHub Actions for test, lint, schema validation | 4h | Continuous quality |
+| 8 | **Centralize ID generation** — One shared utility for ACC-/MR-/TXN-/INV-/EMP- IDs | 2h | Consistency |
+| 9 | **Audit innerHTML usage** — Replace with textContent where safe, DOMPurify where HTML needed | 4h | Security |
+| 10 | **Clean up console.log** — Wrap behind debug flag, strip tt_block.js logs | 2h | Performance |
+| 11 | **Resolve TODO/FIXME markers** — Promote to tracked issues | 1h | Tech debt |
+
+### Long-term Initiatives (> 5 days)
+
+| # | Action | Effort | Impact |
+|---|---|---|---|
+| 12 | **Split TMAR-Accrual-Ledger.html** — Extract into ES modules with build step | 3–5d | Maintainability |
+| 13 | **Add schema version check** — Runtime validation on every GAS↔JS data transfer | 1d | Data integrity |
+| 14 | **Automate dual-source sync** — CI step that diffs `.claude/` ↔ `DOCUMENT_KNOWLEDGE` | 1d | Prevent drift |
+| 15 | **Documentation audit** — Tag all docs as current/historical/draft, archive stale ones | 2d | Onboarding |
+
+---
+
+## Appendix: File Inventory
+
+### Source code (src/)
+```
+src/index.js                        69 lines  — Entry point, exports services
+src/services/AccountService.js     175 lines  — Account CRUD, validation, search
+src/services/TransactionService.js 232 lines  — Transaction CRUD, net income, grouping
+src/services/TMARService.js        399 lines  — High-level orchestrator, Sheets bridge
+src/services/SheetsService.js      363 lines  — Google Sheets read/write, mock data
+src/services/InvoiceService.js     204 lines  — Invoice CRUD, tax calculation (UNUSED)
+src/services/PayrollService.js     247 lines  — Payroll tax calculation (UNUSED)
+src/services/TMARInspectorService.js 293 lines — Function cataloging, monitoring
+src/storage/LocalStorage.js        148 lines  — localStorage wrapper
+src/utils/StateManager.js           87 lines  — Observer-pattern state manager
+```
+
+### Tests (src/__tests__/)
+```
+AccountService.test.js      251 lines  — 16 tests ✓ (well-written)
+StateManager.test.js        126 lines  — 10 tests ✓ (well-written)
+TMARService.test.js         254 lines  — 14 tests ✓ (well-written)
+TMARInspectorService.test.js 85 lines  —  4 tests ✓ (well-written)
+```
+
+### Google Apps Script (gas/)
+```
+Code.gs                  3,576 lines  — onOpen menu, CSV import, data pull
+SyncCenter.gs            2,522 lines  — doGet/doPost, pushEntities, pushForm2848, pushForm1040
+GUIFunctions.gs            530 lines  — Dialogs, sidebars, data query functions
+TMARBridge.gs              349 lines  — Financial summary, addAccount, search
+FormattingComplement.gs    604 lines  — Tab colors, validation, conditional formatting
+ReconcileCrossFill.gs      120 lines  — Cross-tab reconciliation
+PopulateProofOfMailing.gs  127 lines  — Proof of mailing sheet population
+ImportRegistryScan.gs     ≈200 lines  — Registry scan import
+PopulateAppScriptsInventory.gs ≈140 lines — Function catalog
+DuplicateAnalyzer.gs      ≈350 lines  — Account duplicate detection
++ 26 more utility scripts
+```
+
+### HTML tools (tools/)
+```
+TMAR-Accrual-Ledger.html          3,813 KB  — Main application (55,163 lines)
+tools/TMAR-Ecosystem-Navigator.html   38 KB  — Mermaid navigator (12 tabs)
+tools/GAAP-source.html               — GAAP source viewer
+tools/upstream-GAAP.html             — Upstream GAAP interface
+tools/Universal-Process-Tracker.html — Process tracking dashboard
+tools/TMAR_Audit_Dashboard.html      — Audit dashboard
+tools/TMAR-System-Status-Dashboard.html — System status
+tools/tmar-transcript-transformer-v2.html — Transcript Transformer
+tools/_eon_fixes.html                — EON fixes page
+tools/TMAR-Architecture-Diagram.html — Architecture diagram
+```
+
+---
+
+*Generated by Hermes Agent (law profile) via code-auditor skill. Findings based on static analysis of 259+ files. Test coverage data unavailable due to broken test suite.*

--- a/gas/TMARBridge.gs
+++ b/gas/TMARBridge.gs
@@ -194,6 +194,23 @@ function addTMARAccount(accountData) {
 /**
  * Reads accounts from Master Register (helper)
  * @returns {Array<Object>} Array of account objects
+ *
+ * Column mapping corrected 2026-08-06 against the real 29-col (A-AC) schema
+ * (domain-models.md) -- this previously read via getRange(...,35) with offsets
+ * built for the stale 35-column layout, so every field silently pulled from
+ * the wrong column against the live 29-col sheet (e.g. "balance" was reading
+ * Next Payment Due (N) instead of Current Balance (K), "status" was reading
+ * Current Balance (K) instead of Status (H)). This is the read-side twin of
+ * the addTMARAccount() write-side fix from 2026-08-03 -- that one only
+ * covered writes, this covers every caller of this helper (financial
+ * summary, search, per-user filter, JSON export).
+ * "type" reads Account Subtype (G), not Account Type (F), matching
+ * addTMARAccount()'s write convention: F has no confirmed validated dropdown
+ * and is frequently blank, while G is the one column with a confirmed,
+ * exhaustive, validated dropdown (see domain-models.md). monthlyPayment has
+ * no dedicated column in the real schema -- addTMARAccount() folds it into
+ * Notes (AA) as free text, so it is dropped here rather than pointed at a
+ * meaningless column.
  */
 function readMasterRegisterAccounts_() {
   var ss = SpreadsheetApp.getActiveSpreadsheet();
@@ -208,20 +225,19 @@ function readMasterRegisterAccounts_() {
     return [];
   }
 
-  var data = sheet.getRange(2, 1, lastRow - 1, 35).getValues();
+  var data = sheet.getRange(2, 1, lastRow - 1, 29).getValues();
 
   return data.map(function(row) {
     return {
-      id: row[0],
-      dateAdded: row[1],
-      name: row[2],
-      accountNumber: row[5],
-      type: row[6],
-      status: row[10],
-      balance: row[13],
-      monthlyPayment: row[15],
-      primaryUser: row[19],
-      notes: row[32]
+      id: row[0],            // A: Row ID
+      dateAdded: row[1],     // B: Date Added
+      name: row[2],          // C: Provider/Creditor
+      accountNumber: row[4], // E: Account Number
+      type: row[6],          // G: Account Subtype
+      status: row[7],        // H: Status
+      balance: row[10],      // K: Current Balance
+      primaryUser: row[14],  // O: Primary User
+      notes: row[26]         // AA: Notes
     };
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,20 +21,20 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
-      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -53,21 +53,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -84,14 +84,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -101,14 +101,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -128,29 +128,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -180,9 +180,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -200,27 +200,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -285,13 +285,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -327,13 +327,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -453,13 +453,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -469,42 +469,42 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -512,14 +512,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -937,9 +937,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1011,9 +1011,9 @@
       "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1122,13 +1122,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.3.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.2.tgz",
-      "integrity": "sha512-RpV6r/ij22zRRdyBPcxDeKAzH43phWVKEjL2iksqo1Vz3CuBUrgmPpPhALKiRfU7OMCmeeO9vECBMsV0hMTG8Q==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/raf": {
@@ -1178,9 +1178,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1488,9 +1488,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1501,9 +1501,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1525,9 +1525,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -1545,11 +1545,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1588,15 +1588,15 @@
       "license": "MIT"
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -1658,9 +1658,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001807",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001807.tgz",
+      "integrity": "sha512-daRXJ9EB/rdRgu7kV+TTl1YUKtlsMWblPl2sLnpg9DZae16QCegol6A1SmCE31Lm9mXC1sRWGt/krouH+/dl7Q==",
       "dev": true,
       "funding": [
         {
@@ -1829,12 +1829,15 @@
       "license": "MIT"
     },
     "node_modules/core-js": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
-      "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.50.0.tgz",
+      "integrity": "sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "engines": {
+        "node": "*"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -1961,9 +1964,9 @@
       "license": "MIT"
     },
     "node_modules/dedent": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -2106,9 +2109,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "version": "2.5.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.9.tgz",
+      "integrity": "sha512-i6mvVmWN4xo9LrhCOZrDgSs9noW6nOahbrmzjRbPF36YPyj5Ue5lgok0MHDWkG7xzpWFO2OYttXdzM7rJxHvNA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true
     },
@@ -2128,9 +2131,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.402",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.402.tgz",
+      "integrity": "sha512-/oOpMaPT6Yg+6/1XQhyIPlzgj7Ye9zf+nNM2Uh6OcE2G2oNptWazFa+qB2Pdqqbsc9KnIDzgAntoYN0dbwOXwA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2219,9 +2222,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2391,9 +2394,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/fill-range": {
@@ -2440,17 +2443,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2688,9 +2691,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2948,13 +2951,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3215,9 +3218,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4062,9 +4065,9 @@
       "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4218,9 +4221,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4405,9 +4408,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4536,11 +4539,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -4566,9 +4572,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.23",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "dev": true,
       "license": "MIT"
     },
@@ -4798,9 +4804,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4834,35 +4840,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {
@@ -5056,12 +5062,13 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -5225,15 +5232,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -5245,14 +5252,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5617,9 +5624,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5826,14 +5833,14 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",
@@ -5887,9 +5894,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5943,9 +5950,9 @@
       "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- **Fixes a live data-integrity bug**: `readMasterRegisterAccounts_()` in `gas/TMARBridge.gs` was still reading the Master Register with offsets built for the stale 35-column schema, so every caller (Dashboard/ControlPanel financial summary, search, per-user filter, JSON export) silently pulled fields from the wrong live columns — e.g. `balance` read Next Payment Due instead of Current Balance, `status` read Current Balance instead of Status. This is the read-side twin of the `addTMARAccount()` write-side fix from 2026-08-03, which only covered writes.
- Already deployed via `clasp push --force` (not a Web App endpoint, so no manual redeploy needed) — this PR is to land the git-tracked source + doc changes on `master`.
- Syncs `README.md`, `VaultIndex.md`, and `.claude/docs/gas-patterns.md` back to the corrected 29-column (A–AC) schema and the 2026-07-31 Trust Ledger retirement, both of which had drifted since the 8/3 fix.
- Adds `docs/CODE_AUDIT_2026-08-06.md` (Hermes code-audit report) and refreshes `package-lock.json` (declared but not-yet-installed test deps).

## Test plan
- [x] `npm install` clean, `npx jest` — 4 suites / 53 tests pass
- [x] Verified `readMasterRegisterAccounts_()` callers (`ControlPanel.html`, `Dashboard.html`) still consume the returned shape correctly (no reference to the dropped `monthlyPayment` field)
- [x] `clasp push --force` succeeded, fix confirmed live in the Sheet-bound functions
- [ ] Manually re-open the Dashboard sidebar / Control Panel in the Sheet to confirm the financial summary numbers now look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)